### PR TITLE
added: streamlit.tf with ec2 provisioning, new security group, output…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
       aws_account_id: "474668415523"
     secrets:
       google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
 
   deploy-prod:
     name: Deploy to Prod
@@ -31,3 +32,4 @@ jobs:
       aws_account_id: "054037129431"
     secrets:
       google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -12,6 +12,8 @@ on:
     secrets:
       google_client_secret:
         required: true
+      ssh_public_key:
+        required: true
 
 permissions:
   id-token: write
@@ -56,6 +58,7 @@ jobs:
           terraform plan \
             -var="google_client_secret=${{ secrets.google_client_secret }}" \
             -var="environment=${{ inputs.environment }}" \
+            -var="ssh_public_key=${{ secrets.ssh_public_key }}" \
             -out=tfplan
         working-directory: .
 

--- a/sshkeypair.tf
+++ b/sshkeypair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "ec2_access_key" {
+  key_name   = "ec2_key"
+  public_key = var.ssh_public_key  # Define this variable
+}

--- a/streamlit.tf
+++ b/streamlit.tf
@@ -1,0 +1,82 @@
+resource "aws_security_group" "streamlit_sg" {
+  name        = "studentportal-streamlit-sg"
+  description = "Allow inbound access to Streamlit app"
+  vpc_id      = aws_vpc.main.id
+
+  # Allow Streamlit web traffic on port 8501
+  ingress {
+    from_port   = 8501
+    to_port     = 8501
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow SSH access for your manual configuration
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Consider restricting this to your IP
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "streamlit-security-group"
+  }
+}
+
+# EC2 instance for the Streamlit app (minimal configuration)
+resource "aws_instance" "streamlit" {
+  ami                    = "ami-0eb260c4d5475b901"  # Amazon Linux 2023 AMI
+  instance_type          = "t2.micro"
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.streamlit_sg.id]
+  iam_instance_profile   = aws_iam_instance_profile.streamlit_profile.name
+  key_name               = aws_key_pair.ec2_access_key.key_name  # Reference the key pair here
+
+  tags = {
+    Name = "streamlit-instance"
+  }
+}
+
+# IAM Role and Instance Profile for EC2
+resource "aws_iam_role" "streamlit_role" {
+  name = "streamlit-app-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "streamlit_profile" {
+  name = "streamlit-app-profile"
+  role = aws_iam_role.streamlit_role.name
+}
+
+# Output the public IP for SSH access
+output "streamlit_instance_ip" {
+  value       = aws_instance.streamlit.public_ip
+  description = "Public IP of the Streamlit EC2 instance"
+}
+
+# Output the future Streamlit URL for reference
+output "streamlit_url" {
+  value       = "http://${aws_instance.streamlit.public_ip}:8501"
+  description = "URL to access the Streamlit app (after manual configuration)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "private_subnet_cidr" {
 variable "environment" {
   type = string
 }
+
+variable "ssh_public_key" {
+  description = "Public SSH key for EC2 instance access"
+  type        = string
+  sensitive   = true  # Mark as sensitive
+}


### PR DESCRIPTION
This pull request includes several important changes to the deployment and infrastructure configuration files, focusing on adding SSH key support and configuring a new EC2 instance for a Streamlit application.

### SSH Key Support:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R23): Added `ssh_public_key` to the secrets for both `aws_account_id` sections. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R23) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R35)
* [`.github/workflows/terraform-deploy.yml`](diffhunk://#diff-16f5deded229cb775f642323663a8453ffb45ba64dae8d8d3de4f734156c235eR15-R16): Added `ssh_public_key` to the required secrets and passed it as a variable in the Terraform plan. [[1]](diffhunk://#diff-16f5deded229cb775f642323663a8453ffb45ba64dae8d8d3de4f734156c235eR15-R16) [[2]](diffhunk://#diff-16f5deded229cb775f642323663a8453ffb45ba64dae8d8d3de4f734156c235eR61)
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR43-R48): Introduced a new variable `ssh_public_key` marked as sensitive.

### Streamlit Application Configuration:
* [`streamlit.tf`](diffhunk://#diff-95bb74312a8b8d275ead8b609d0d409f60b0ef009377eeff4f42ff3fe1ecd0f0R1-R82): Added resources for an EC2 instance, security group, IAM role, and instance profile for a Streamlit application, including outputs for the instance's public IP and the Streamlit URL.

### EC2 Key Pair:
* [`sshkeypair.tf`](diffhunk://#diff-c3e0628106575d9bc100c5f7e5f8d25368ddc57201e611bec973852a0b5a7451R1-R4): Created a new AWS key pair resource using the `ssh_public_key` variable.