### PR TITLE
Lambda + API for cognito edits

### DIFF
--- a/lambdas.tf
+++ b/lambdas.tf
@@ -97,6 +97,25 @@ resource "aws_lambda_function" "get_student_courses" {
   tags = local.common_tags
 }
 
+# Lambda function for updating user profiles
+resource "aws_lambda_function" "update_profile" {
+  function_name = "update-user-profile"
+  role          = aws_iam_role.update_profile_role.arn
+  filename      = "${path.module}/dummy_lambda.zip" # This will be replaced by actual deployment
+  handler       = "index.handler"
+  runtime       = "nodejs18.x"
+  timeout       = 30
+  memory_size   = 256
+  
+  environment {
+    variables = {
+      USER_POOL_ID = aws_cognito_user_pool.students.id
+    }
+  }
+  
+  tags = local.common_tags
+}
+
 # Worker Lambda functions (in Private Subnet)
 # resource "aws_lambda_function" "get_student_degree" {
 #   function_name = "get-student-degree"

--- a/student-api.tf
+++ b/student-api.tf
@@ -41,3 +41,35 @@ resource "aws_lambda_permission" "api_gateway_orchestrator" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/${aws_api_gateway_method.query_post.http_method}${aws_api_gateway_resource.query.path}"
 }
+
+# API gateway resource to handle SSO profile edits
+resource "aws_api_gateway_resource" "user_profile" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  path_part   = "profile"
+}
+
+resource "aws_api_gateway_method" "update_profile" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.user_profile.id
+  http_method   = "PUT"
+  authorization = "COGNITO_USER_POOLS"
+  authorizer_id = aws_api_gateway_authorizer.students_authorizer.id
+}
+
+resource "aws_api_gateway_integration" "update_profile_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.user_profile.id
+  http_method             = aws_api_gateway_method.update_profile.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.update_profile.invoke_arn
+}
+
+resource "aws_lambda_permission" "api_gateway_update_profile" {
+  statement_id  = "AllowAPIGatewayInvokeUpdateProfile"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.update_profile.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/${aws_api_gateway_method.update_profile.http_method}${aws_api_gateway_resource.user_profile.path}"
+}


### PR DESCRIPTION
This pull request introduces new resources to support a Lambda function for updating user profiles in AWS Cognito. The main changes include adding IAM roles and policies, creating the Lambda function, and configuring API Gateway resources to handle profile updates.

### IAM Roles and Policies:

* Added a new IAM role `aws_iam_role.update_profile_role` for the Lambda function to assume.
* Created a new IAM policy `aws_iam_policy.update_profile_policy` to allow the Lambda function to update user attributes in Cognito.
* Attached the new policy to the IAM role using `aws_iam_role_policy_attachment.update_profile_policy_attachment`.

### Lambda Function:

* Added a new Lambda function `aws_lambda_function.update_profile` to handle user profile updates.

### API Gateway:

* Created a new API Gateway resource `aws_api_gateway_resource.user_profile` to handle profile edit requests.
* Added a new API Gateway method `aws_api_gateway_method.update_profile` for handling PUT requests to update profiles.
* Configured an API Gateway integration `aws_api_gateway_integration.update_profile_integration` to connect the PUT method to the Lambda function.
* Granted API Gateway permission to invoke the Lambda function using `aws_lambda_permission.api_gateway_update_profile`.